### PR TITLE
Avviso SPID n. 19 v.4 - gestori di pubblico servizio [DEF]

### DIFF
--- a/example/spid_config/spid_settings.py
+++ b/example/spid_config/spid_settings.py
@@ -40,7 +40,8 @@ SPID_PREFIXES = dict(
     spid='https://spid.gov.it/saml-extensions',
     fpa='https://spid.gov.it/invoicing-extensions'
 )
-
+# Avviso SPID n. 19 v.4 per enti AGGREGATORI aggiungere chiave vuota PublicServicesFullOperator
+# Il plugin genererà automaticamente anche il tag ContactPerson con l’attributo spid:entityType valorizzato a spid:aggregator
 SPID_CONTACTS = [
     {
         'contact_type': 'other',
@@ -48,7 +49,8 @@ SPID_CONTACTS = [
         'email_address': 'tech-info@example.org',
         'VATNumber': 'IT12345678901',
         'FiscalCode': 'XYZABCAAMGGJ000W',
-        'Private': ''
+        'Private': '',
+        #'PublicServicesFullOperator':''
     },
     {
         'contact_type': 'billing',
@@ -67,11 +69,12 @@ SPID_CONTACTS = [
         'Nazione': 'IT',
     },
 ]
-
+# Avviso SPID n. 19 v.4 per enti AGGREGATORI l’entityID deve contenere il codice attività pub-op-full
 SAML_CONFIG = {
     'debug': True,
     'xmlsec_binary': get_xmlsec_binary(['/opt/local/bin', '/usr/bin/xmlsec1']),
     'entityid': f'{SPID_BASE_URL}metadata',
+    #'entityid': f'{BASE_URL}/pub-op-full/',
     'attribute_map_dir': f'{BASE_DIR}/spid_config/attribute-maps/',
 
     'service': {

--- a/src/djangosaml2_spid/views.py
+++ b/src/djangosaml2_spid/views.py
@@ -374,13 +374,15 @@ def avviso_29_v3(metadata):
                 'Extensions',
                 namespace='urn:oasis:names:tc:SAML:2.0:metadata'
             )
-            for k, v in contact.items():
-                if k in contact_kwargs:
-                    continue
+            for k,v in contact.items():
+                if k in contact_kwargs: continue
+                #Avviso SPID n. 19 v.4 per enti AGGREGATORI il tag ContactPerson deve avere l’attributo spid:entityType valorizzato come spid:aggregator
+                if k=="PublicServicesFullOperator":
+                    spid_contact.extension_attributes= {"spid:entityType": "spid:aggregator"}
                 ext = saml2.ExtensionElement(
-                    k,
-                    namespace=settings.SPID_PREFIXES['spid'],
-                    text=v
+                        k, 
+                        namespace=settings.SPID_PREFIXES['spid'],
+                        text=v
                 )
                 spid_extensions.children.append(ext)
 


### PR DESCRIPTION
Essendo voi gestori di pubblico servizio, dovete essere conformi all’Avviso SPID n. 19 v.4 (https://www.agid.gov.it/sites/default/files/repository_files/spid-avviso-n19v4-regole_tecniche_aggregatori_0.pdf) ed in particolare:

      l’entityID deve contenere il codice attività pub-op-full

      il tag ContactPerson deve avere l’attributo spid:entityType valorizzato come spid:aggregator e deve contenere, nel tag Extensions, il tag vuoto PublicServicesFullOperator

Si rende quindi necessario aggiungere l'attributo spid:entityType valorizzato come spid:aggregator a "ContactPerson" se viene inserito il tag "PublicServicesFullOperator" 

#Avviso SPID n. 19 v.4 - gestori di pubblico servizio #25 