### PR TITLE
Fix settings loading in app modules

### DIFF
--- a/src/djangosaml2_spid/management/commands/update_idps.py
+++ b/src/djangosaml2_spid/management/commands/update_idps.py
@@ -1,9 +1,9 @@
-from django.conf import settings
 from django.core.management.base import BaseCommand
 import json
 import os
 import requests
 
+from djangosaml2_spid.conf import settings
 
 SPID_IDENTITY_PROVIDERS_URL = settings.SPID_IDENTITY_PROVIDERS_URL
 SPID_IDENTITY_PROVIDERS_METADATA_DIR = settings.SPID_IDENTITY_PROVIDERS_METADATA_DIR

--- a/src/djangosaml2_spid/spid_metadata.py
+++ b/src/djangosaml2_spid/spid_metadata.py
@@ -1,7 +1,8 @@
 import saml2
-from django.conf import settings
 from saml2.metadata import entity_descriptor, sign_entity_descriptor
 from saml2.sigver import security_context
+
+from .conf import settings
 
 
 def spid_sp_metadata(conf):
@@ -75,9 +76,10 @@ def avviso_29_v3(metadata):
                     namespace=settings.SPID_PREFIXES['spid'],
                     text=v
                 )
-                # Avviso SPID n. 19 v.4 per enti AGGREGATORI il tag ContactPerson deve avere l’attributo spid:entityType valorizzato come spid:aggregator
+                # Avviso SPID n. 19 v.4 per enti AGGREGATORI il tag ContactPerson deve avere
+                # l’attributo spid:entityType valorizzato come spid:aggregator
                 if k == "PublicServicesFullOperator":
-                    spid_contact.extension_attributes= {"spid:entityType": "spid:aggregator"}
+                    spid_contact.extension_attributes = {"spid:entityType": "spid:aggregator"}
 
                 spid_extensions.children.append(ext)
 

--- a/src/djangosaml2_spid/spid_request.py
+++ b/src/djangosaml2_spid/spid_request.py
@@ -1,15 +1,13 @@
 import logging
 
 import saml2
-from django.conf import settings
 from django.urls import reverse
 from djangosaml2.overrides import Saml2Client
 from saml2.authn_context import requested_authn_context
 
+from .conf import settings
 
-SAML2_DEFAULT_BINDING = getattr(
-    settings, 'SAML2_DEFAULT_BINDING', saml2.BINDING_HTTP_POST
-)
+SAML2_DEFAULT_BINDING = settings.SAML2_DEFAULT_BINDING
 
 logger = logging.getLogger('djangosaml2')
 
@@ -26,7 +24,8 @@ def spid_sp_authn_request(conf, selected_idp, next_url=''):
 
     authn_req = saml2.samlp.AuthnRequest()
     authn_req.destination = location_fixed
-    # spid-testenv2 preleva l'attribute consumer service dalla authnRequest (anche se questo sta già nei metadati...)
+    # spid-testenv2 preleva l'attribute consumer service dalla authnRequest
+    # (anche se questo sta già nei metadati...)
     authn_req.attribute_consuming_service_index = "0"
 
     # issuer

--- a/src/djangosaml2_spid/urls.py
+++ b/src/djangosaml2_spid/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from django.conf import settings
+from .conf import settings
 from . import views
 
 


### PR DESCRIPTION
Better loading from *djangosaml2_spid.conf* instead of from common *django.conf* module in order to have all app defaults defined.
This fix the run of _update_idps.py_ command when SPID_IDENTITY_PROVIDERS_URL is not set (so the default should be used).