### PR TITLE
Remove access to optional settings at module level in command update_idps.py

### DIFF
--- a/src/djangosaml2_spid/management/commands/update_idps.py
+++ b/src/djangosaml2_spid/management/commands/update_idps.py
@@ -5,28 +5,24 @@ import os
 import requests
 
 
-SPID_IDENTITY_PROVIDERS_URL = settings.SPID_IDENTITY_PROVIDERS_URL
-SPID_IDENTITY_PROVIDERS_METADATA_DIR = settings.SPID_IDENTITY_PROVIDERS_METADATA_DIR
-
-
 class Command(BaseCommand):
     help = 'Download and write all the official identity providers metadata XML files'
 
     def handle(self, *args, **options):
-        self.write_identity_providers_metadatas()
+        self.write_identity_providers_metadata()
 
-    def write_identity_providers_metadatas(self):
+    def write_identity_providers_metadata(self):
         identity_providers = self.download_identity_providers()
 
         self.print(f'Starting writing of IdPs metadata XML files '
-                   f'into {SPID_IDENTITY_PROVIDERS_METADATA_DIR}:')
+                   f'into {settings.SPID_IDENTITY_PROVIDERS_METADATA_DIR}:')
 
         for identity_provider in identity_providers:
             idp_entity_code = identity_provider['ipa_entity_code']
             idp_entity_name = identity_provider['entity_name']
             idp_metadata = identity_provider['metadata']
             metadata_file_path = os.path.join(
-                SPID_IDENTITY_PROVIDERS_METADATA_DIR, f'{idp_entity_code}.xml')
+                settings.SPID_IDENTITY_PROVIDERS_METADATA_DIR, f'{idp_entity_code}.xml')
 
             self.print(f'Writing metadata XML file for IdP {idp_entity_name} '
                        f'into {metadata_file_path}', indentation_level=1)
@@ -35,16 +31,16 @@ class Command(BaseCommand):
                 metadata_file.write(idp_metadata)
 
         self.print_success(f'Successfully wrote all IdPs metadata XML files '
-                           f'into {SPID_IDENTITY_PROVIDERS_METADATA_DIR}')
+                           f'into {settings.SPID_IDENTITY_PROVIDERS_METADATA_DIR}')
 
     def download_identity_providers(self):
         self.print(f'Starting download of identity providers (IdPs) '
-                   f'official list from {SPID_IDENTITY_PROVIDERS_URL}')
+                   f'official list from {settings.SPID_IDENTITY_PROVIDERS_URL}')
 
-        with requests.get(SPID_IDENTITY_PROVIDERS_URL, verify=True) as response:
+        with requests.get(settings.SPID_IDENTITY_PROVIDERS_URL, verify=True) as response:
             identity_providers = json.loads(response.content)['data']
 
-        self.print('Downloaded IdPs official list, starting IdPs metadatas download:')
+        self.print('Downloaded IdPs official list, starting IdPs metadata download:')
 
         for identity_provider in identity_providers:
             idp_entity_name = identity_provider['entity_name']
@@ -56,7 +52,7 @@ class Command(BaseCommand):
             with requests.get(idp_metadata_url, verify=True) as response:
                 identity_provider['metadata'] = response.text
 
-        self.print_success('All IdPs metadatas downloaded successfully')
+        self.print_success('All IdPs metadata downloaded successfully')
 
         return identity_providers
 


### PR DESCRIPTION
Fix *update_idps.py* for cases when SPID_IDENTITY_PROVIDERS_URL or SPID_IDENTITY_PROVIDERS_METADATA_DIR are not explicitly provided in project's *settings.py*. In these cases the default settings should be used.

The fix removes the access to these settings at module level, avoiding the raising of an attribute error:
```
AttributeError: 'Settings' object has no attribute 'SPID_IDENTITY_PROVIDERS_URL'
```