### PR TITLE
Add SPID_BASE_URL setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ djangosaml2_spid uses a pySAML2 fork.
 * Register the SP metadata to your test Spid IDPs
 * Start the django server for tests `./manage.py runserver 0.0.0.0:8000`
 
----
-**NOTE**
+Minimal SPID settings
+---------------------
 
 Instead of copy the whole demo project configuration you can add only the
 necessary configuration entries (eg. SAML_CONFIG with 'organization' info,
@@ -131,8 +131,39 @@ and SPID_CONTACTS, other configurations that you want to be different from
 defaults) directly to your project settings file. In this case don't
 add `'spid_config'` to `settings.INSTALLED_APPS`.
 
----
+An example of a minimal configuration for SPID is the following:
 
+```python
+SAML_CONFIG = {
+    'organization': {
+        'name': [('Example', 'it'), ('Example', 'en')],
+        'display_name': [('Example', 'it'), ('Example', 'en')],
+        'url': [('http://www.example.it', 'it'), ('http://www.example.it', 'en')],
+    },
+}
+
+SAML_USE_NAME_ID_AS_USERNAME = False
+SAML_DJANGO_USER_MAIN_ATTRIBUTE = 'username'
+SAML_CREATE_UNKNOWN_USER = True
+SAML_DJANGO_USER_MAIN_ATTRIBUTE_LOOKUP = '__iexact'
+SAML_ATTRIBUTE_MAPPING = {
+    'spidCode': ('username', ),
+    'email': ('email', ),
+    'name': ('first_name', ),
+    'familyName': ('last_name', ),
+}
+
+SPID_CONTACTS = [
+    {
+        'contact_type': 'other',
+        'telephone_number': '+39 8475634785',
+        'email_address': 'tech-info@example.org',
+        'VATNumber': 'IT12345678901',
+        'FiscalCode': 'XYZABCAAMGGJ000W',
+        'Private': '',
+    },
+]
+```
 
 Attribute Mapping
 -----------------

--- a/example/spid_config/spid_settings.py
+++ b/example/spid_config/spid_settings.py
@@ -6,6 +6,7 @@ import saml2
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+SPID_BASE_URL = "http://localhost:8000"
 SPID_URLS_PREFIX = 'spid'
 
 SPID_ACS_URL_PATH = f'{SPID_URLS_PREFIX}/acs/'
@@ -37,8 +38,6 @@ SPID_SAML_CHECK_METADATA_URL = os.environ.get('SPID_SAML_CHECK_METADATA_URL', 'h
 
 SPID_TESTENV2_REMOTE_METADATA_ACTIVE = os.environ.get('SPID_TESTENV2_REMOTE_METADATA_ACTIVE', 'False') == 'True'
 SPID_TESTENV2_METADATA_URL = os.environ.get('SPID_TESTENV2_METADATA_URL', 'http://localhost:8088/metadata')
-
-BASE_URL = "http://localhost:8000"
 
 # Avviso 29v3
 SPID_PREFIXES = dict(
@@ -98,26 +97,27 @@ SAML_CONFIG = {
     # configurations, adapted for the running Django service on the basis of the
     # defined SPID_* settings.
 
-    # TODO: Avviso SPID n. 19 v.4 per enti AGGREGATORI l’entityID deve contenere il codice attività pub-op-full
-    #'entityid': f'{BASE_URL}/pub-op-full/',  # TODO: Aggiungere voce di configurazione SPID_* apposita??
-    'entityid': f'{BASE_URL}/{SPID_URLS_PREFIX}/metadata/',
+    # TODO: Avviso SPID n. 19 v.4 per enti AGGREGATORI l’entityID deve contenere
+    #  il codice attività pub-op-full
+    #'entityid': f'{SPID_BASE_URL}/pub-op-full/',  # TODO: Aggiungere voce di configurazione SPID_ENTITYID apposita??
+    'entityid': f'{SPID_BASE_URL}/{SPID_URLS_PREFIX}/metadata/',
 
     'attribute_map_dir': f'{BASE_DIR}/djangosaml2_spid/attribute_maps/',
 
     'service': {
         'sp': {
-            'name': f'{BASE_URL}/{SPID_URLS_PREFIX}/metadata/',
-            'name_qualifier': f'{BASE_URL}',
+            'name': f'{SPID_BASE_URL}/{SPID_URLS_PREFIX}/metadata/',
+            'name_qualifier': f'{SPID_BASE_URL}',
 
             'name_id_format': [SPID_NAMEID_FORMAT],
 
             'endpoints': {
                 'assertion_consumer_service': [
-                    (f'{BASE_URL}/{SPID_ACS_URL_PATH}',
+                    (f'{SPID_BASE_URL}/{SPID_ACS_URL_PATH}',
                      saml2.BINDING_HTTP_POST),
                 ],
                 'single_logout_service': [
-                    (f'{BASE_URL}/{SPID_SLO_POST_URL_PATH}',
+                    (f'{SPID_BASE_URL}/{SPID_SLO_POST_URL_PATH}',
                      saml2.BINDING_HTTP_POST),
                 ],
             },

--- a/runtests.py
+++ b/runtests.py
@@ -13,7 +13,9 @@ if __name__ == "__main__":
     os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.test_settings'
     django.setup()
     TestRunner = get_runner(settings)
-    test_runner = TestRunner()
-    failures = test_runner.run_tests(['tests', 'src'])
+    test_runner = TestRunner(verbosity=2 if '-v' in sys.argv else 1,
+                             failfast='-f' in sys.argv)
+    test_labels = [arg for arg in sys.argv[1:]
+                   if arg.startswith('tests') or arg.startswith('djangosaml2_spid')]
+    failures = test_runner.run_tests(test_labels or ['tests', 'src'])
     sys.exit(bool(failures))
-

--- a/src/djangosaml2_spid/tests.py
+++ b/src/djangosaml2_spid/tests.py
@@ -57,10 +57,12 @@ class TestSpidConfig(TestCase):
         saml_config = get_config(request=request)
         self.assertEqual(saml_config.entityid, 'http://localhost:8000/spid/metadata/')
 
-        request = self.factory.get('/spid/metadata')
-        saml_config = get_config(request=request)
-        self.assertEqual(saml_config.entityid, 'http://testserver/spid/metadata/')
+        if base_dir.name != 'example':
+            request = self.factory.get('/spid/metadata')
+            saml_config = get_config(request=request)
+            self.assertEqual(saml_config.entityid, 'http://testserver/spid/metadata/')
 
+    @unittest.skipIf(base_dir.name == 'example', "Skip for demo project")
     def test_default_spid_saml_config(self):
         request = self.factory.get('/spid/metadata')
         saml_config = get_config(request=request)

--- a/src/djangosaml2_spid/utils.py
+++ b/src/djangosaml2_spid/utils.py
@@ -3,9 +3,7 @@ import base64
 import xml.dom.minidom
 import zlib
 
-from django.conf import settings
 from xml.parsers.expat import ExpatError
-from saml2.config import SPConfig
 
 
 def repr_saml_request(saml_str, b64=False):
@@ -38,12 +36,3 @@ def saml_request_from_html_form(html_str):
         raise ValueError('AuthnRequest not found in htmlform')
 
     return authn_request[0]
-
-
-def get_config(config_loader_path=None, request=None):
-    conf = getattr(settings, 'SAML_CONFIG', None)
-    if conf:
-        conf = SPConfig().load(conf)
-    if not conf:
-        conf = get_config(config_loader_path, request)
-    return conf

--- a/src/djangosaml2_spid/views.py
+++ b/src/djangosaml2_spid/views.py
@@ -19,6 +19,7 @@ from djangosaml2.utils import (
 from saml2 import BINDING_HTTP_REDIRECT, BINDING_HTTP_POST
 from saml2.mdstore import UnknownSystemEntity
 from saml2.s_utils import UnsupportedBinding
+from djangosaml2.conf import get_config
 import djangosaml2.views as djangosaml2_views
 import logging
 import saml2
@@ -29,7 +30,6 @@ from .spid_metadata import spid_sp_metadata
 from .spid_request import spid_sp_authn_request, SAML2_DEFAULT_BINDING
 from .spid_validator import Saml2ResponseValidator
 from .utils import repr_saml_request
-from .utils import get_config
 
 logger = logging.getLogger('djangosaml2')
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -126,7 +126,7 @@ STATIC_URL = '/static/'
 
 # PySAML2 base settings
 SAML_CONFIG = {
-    'entityid': 'http://localhost:8000/spid/metadata',  # Only for testing, usually detected.
+    'entityid': 'http://localhost:8000/spid/metadata/',  # Only for testing, usually detected.
 
     'organization': {
         'name': [('Example', 'it'), ('Example', 'en')],


### PR DESCRIPTION
Questa PR ripristina la modalità di configurazione dinamica per sistemare il problema della coerenza del metadata con la URL del servizio. 

Questa coerenza può essere lasciata dinamica o forzata ad un valore specifico tramite la nuova impostazione **SPID_BASE_URL**.
Questa opzione dovrebbe consentire di superare i problemi di validazione riscontrati recentemente con il validatore SPID dockerizzato.

Se non dovesse essere sufficiente a risolverlo, piuttosto che eliminare la dinamicità della configurazione si potrebbe prendere in ipotesi l'aggiunta si una configurazione specifica per l'entityID, che ne forzi il valore. La configurazione dinamica, prevista in djangosaml2, può comunque essere sovrascritta come si vuole con un setting nel progetto. 

Lasciare la configurazione dinamica permette di minimizzare i settings, rendere più semplici gli update della app SPID e poter ospitare più configurazioni SAML sullo stesso sito.

In questa PR è stato aggiunto anche un esempio di configurazione minima in README.md.