### PR TITLE
Impostare allow_unsolicited = True nella configurazione SAML2 di SPID

### DIFF
--- a/example/spid_config/spid_settings.py
+++ b/example/spid_config/spid_settings.py
@@ -77,134 +77,24 @@ SPID_CONTACTS = [
 ]
 
 
-# Configuration for pysaml2 managed by djangosaml2, that is usually replaced or
-# updated by a dynamic configurations adapted for the running Django service.
+# Configuration for pysaml2 as managed by djangosaml2. For SPID SP service the most
+# part is built dynamically from provided SPID_* settings and from SPID_* defaults.
 SAML_CONFIG = {
-    #
-    # Non SPID-only related info are used for building dynamic running config.
-
-    # you can set multilanguage information here
+    # Required organization info, you can set multi-language information here.
     'organization': {
         'name': [('Example', 'it'), ('Example', 'en')],
         'display_name': [('Example', 'it'), ('Example', 'en')],
         'url': [('http://www.example.it', 'it'), ('http://www.example.it', 'en')],
     },
+
+    # Other common options used by SPID configuration
     'debug': True,
     'xmlsec_binary': get_xmlsec_binary(['/opt/local/bin', '/usr/bin/xmlsec1']),
 
-    # The following entries are reported here only for show a complete configuration
-    # for pysaml2. When a SPID URL is requested these entries are replaced by proper
-    # configurations, adapted for the running Django service on the basis of the
-    # defined SPID_* settings.
-
-    # TODO: Avviso SPID n. 19 v.4 per enti AGGREGATORI l’entityID deve contenere
-    #  il codice attività pub-op-full
-    #'entityid': f'{SPID_BASE_URL}/pub-op-full/',  # TODO: Aggiungere voce di configurazione SPID_ENTITYID apposita??
-    'entityid': f'{SPID_BASE_URL}/{SPID_URLS_PREFIX}/metadata/',
-
-    'attribute_map_dir': f'{BASE_DIR}/djangosaml2_spid/attribute_maps/',
-
-    'service': {
-        'sp': {
-            'name': f'{SPID_BASE_URL}/{SPID_URLS_PREFIX}/metadata/',
-            'name_qualifier': f'{SPID_BASE_URL}',
-
-            'name_id_format': [SPID_NAMEID_FORMAT],
-
-            'endpoints': {
-                'assertion_consumer_service': [
-                    (f'{SPID_BASE_URL}/{SPID_ACS_URL_PATH}',
-                     saml2.BINDING_HTTP_POST),
-                ],
-                'single_logout_service': [
-                    (f'{SPID_BASE_URL}/{SPID_SLO_POST_URL_PATH}',
-                     saml2.BINDING_HTTP_POST),
-                ],
-            },
-
-            # Mandates that the IdP MUST authenticate the presenter directly
-            # rather than rely on a previous security context.
-            'force_authn': False,  # SPID
-            'name_id_format_allow_create': False,
-
-            # attributes that this project need to identify a user
-            'required_attributes': [
-                'spidCode',
-                'name',
-                'familyName',
-                'fiscalNumber',
-                'email'
-            ],
-
-            'requested_attribute_name_format': saml2.saml.NAME_FORMAT_BASIC,
-            'name_format': saml2.saml.NAME_FORMAT_BASIC,
-
-            # attributes that may be useful to have but not required
-            'optional_attributes': [
-                'gender',
-                'companyName',
-                'registeredOffice',
-                'ivaCode',
-                'idCard',
-                'digitalAddress',
-                'placeOfBirth',
-                'countyOfBirth',
-                'dateOfBirth',
-                'address',
-                'mobilePhone',
-                'expirationDate'
-            ],
-
-            'signing_algorithm': SPID_SIG_ALG,
-            'digest_algorithm': SPID_DIG_ALG,
-
-            'authn_requests_signed': True,
-            'logout_requests_signed': True,
-
-            # Indicates that Authentication Responses to this SP must
-            # be signed. If set to True, the SP will not consume
-            # any SAML Responses that are not signed.
-            'want_assertions_signed': True,
-
-            # When set to true, the SP will consume unsolicited SAML
-            # Responses, i.e. SAML Responses for which it has not sent
-            # a respective SAML Authentication Request.
-            'allow_unsolicited': False,
-
-            # Permits to have attributes not configured in attribute-mappings
-            # otherwise...without OID will be rejected
-            'allow_unknown_attributes': True,
-        },
-    },
-
-    # many metadata, many idp...
-    'metadata': {
-        'local': [
-            SPID_IDENTITY_PROVIDERS_METADATA_DIR
-        ],
-        'remote': []
-    },
-
-    # Signing
-    'key_file': SPID_PRIVATE_KEY,
-    'cert_file': SPID_PUBLIC_CERT,
-
-    # Encryption
-    'encryption_keypairs': [{
-        'key_file': SPID_PRIVATE_KEY,
-        'cert_file': SPID_PUBLIC_CERT,
-    }],
+    # The other entries are dynamically generated from SPID_* provided settings
+    # and defaults. You can still provide those entries here but they can useful
+    # only for other SAML2 service in your installation, not for SPID.
 }
-
-if SPID_SAML_CHECK_REMOTE_METADATA_ACTIVE:
-    SAML_CONFIG['metadata']['remote'].append(
-        {'url': SPID_SAML_CHECK_METADATA_URL}
-    )
-
-if SPID_TESTENV2_REMOTE_METADATA_ACTIVE:
-    SAML_CONFIG['metadata']['remote'].append(
-        {'url': SPID_TESTENV2_METADATA_URL}
-    )
 
 # OR NAME_ID or MAIN_ATTRIBUTE (not together!)
 SAML_USE_NAME_ID_AS_USERNAME = False

--- a/src/djangosaml2_spid/conf.py
+++ b/src/djangosaml2_spid/conf.py
@@ -248,8 +248,9 @@ def config_settings_loader(request: Optional[HttpRequest] = None) -> SPConfig:
 
                 # When set to true, the SP will consume unsolicited SAML
                 # Responses, i.e. SAML Responses for which it has not sent
-                # a respective SAML Authentication Request.
-                'allow_unsolicited': False,
+                # a respective SAML Authentication Request. Set to True to
+                # let ACS endpoint work.
+                'allow_unsolicited': True,
 
                 # Permits to have attributes not configured in attribute-mappings
                 # otherwise...without OID will be rejected

--- a/src/djangosaml2_spid/tests.py
+++ b/src/djangosaml2_spid/tests.py
@@ -51,16 +51,19 @@ class TestSpidConfig(TestCase):
 
     def test_get_config(self):
         saml_config = get_config()
-        self.assertEqual(saml_config.entityid, 'http://localhost:8000/spid/metadata/')
+        self.assertIsNone(saml_config.entityid)
 
         request = self.factory.get('')
         saml_config = get_config(request=request)
-        self.assertEqual(saml_config.entityid, 'http://localhost:8000/spid/metadata/')
+        self.assertIsNone(saml_config.entityid)
 
+        # SPConfig for a SPID request
+        request = self.factory.get('/spid/metadata')
+        saml_config = get_config(request=request)
         if base_dir.name != 'example':
-            request = self.factory.get('/spid/metadata')
-            saml_config = get_config(request=request)
             self.assertEqual(saml_config.entityid, 'http://testserver/spid/metadata/')
+        else:
+            self.assertEqual(saml_config.entityid, 'http://localhost:8000/spid/metadata/')
 
     @unittest.skipIf(base_dir.name == 'example', "Skip for demo project")
     def test_default_spid_saml_config(self):
@@ -113,7 +116,6 @@ class TestSpidConfig(TestCase):
 
     @override_settings(SAML_CONFIG={
         'debug': True,
-        'entityid': settings.SAML_CONFIG['entityid'],
         'organization': settings.SAML_CONFIG['organization'],
     })
     def test_saml_debug_mode(self):
@@ -122,7 +124,6 @@ class TestSpidConfig(TestCase):
         self.assertTrue(saml_config.debug)
 
     @override_settings(SAML_CONFIG={
-        'entityid': settings.SAML_CONFIG['entityid'],
         'organization': settings.SAML_CONFIG['organization'],
     })
     def test_saml_no_debug_mode(self):

--- a/src/djangosaml2_spid/views.py
+++ b/src/djangosaml2_spid/views.py
@@ -313,6 +313,7 @@ class EchoAttributesView(LoginRequiredMixin,
 
 
 class AssertionConsumerServiceView(djangosaml2_views.AssertionConsumerServiceView):
+
     def custom_validation(self, response):
         conf = get_config(None, self.request)
 
@@ -320,17 +321,12 @@ class AssertionConsumerServiceView(djangosaml2_views.AssertionConsumerServiceVie
         accepted_time_diff = conf.accepted_time_diff
         recipient = conf._sp_endpoints['assertion_consumer_service'][0][0]
         authn_context_classref = settings.SPID_AUTH_CONTEXT
-        issuer = response.response.issuer
-        # in_response_to = todo
-        validator = Saml2ResponseValidator(authn_response = response.xmlstr,
-                                           recipient = recipient,
-                                           # in_response_to = in_response_to,
-                                           # requester = requester,
+        validator = Saml2ResponseValidator(authn_response=response.xmlstr,
+                                           recipient=recipient,
                                            accepted_time_diff = accepted_time_diff,
                                            authn_context_class_ref = authn_context_classref,
                                            return_addrs = response.return_addrs)
         validator.run()
-
 
     def handle_acs_failure(self, request, exception=None, status=403, **kwargs):
         if isinstance(exception, SpidAnomaly):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -126,8 +126,6 @@ STATIC_URL = '/static/'
 
 # PySAML2 base settings
 SAML_CONFIG = {
-    'entityid': 'http://localhost:8000/spid/metadata/',  # Only for testing, usually detected.
-
     'organization': {
         'name': [('Example', 'it'), ('Example', 'en')],
         'display_name': [('Example', 'it'), ('Example', 'en')],


### PR DESCRIPTION
Per consentire all'endpoint ACS di funzionare correttamente servirebbe abilitare le SAML response che non hanno una corrispondente request.

Questa PR include anche una pulizia dei parametri ignorati nella configurazione della demo, con l'aggiunta di note di chiarimento. 