### PR TITLE
Forceauthn depends by ACR

### DIFF
--- a/src/djangosaml2_spid/conf.py
+++ b/src/djangosaml2_spid/conf.py
@@ -71,8 +71,22 @@ settings.SPID_SIG_ALG = getattr(settings, 'SPID_SIG_ALG', SIG_RSA_SHA256)
 settings.SPID_NAMEID_FORMAT = getattr(
     settings, 'SPID_NAMEID_FORMAT', NAMEID_FORMAT_TRANSIENT
 )
+
+SPID_ACR_L1 = 'https://www.spid.gov.it/SpidL1'
+SPID_ACR_L2 = 'https://www.spid.gov.it/SpidL2'
+SPID_ACR_L3 = 'https://www.spid.gov.it/SpidL3'
+
 settings.SPID_AUTH_CONTEXT = getattr(
-    settings, 'SPID_AUTH_CONTEXT', 'https://www.spid.gov.it/SpidL1'
+    settings, 'SPID_AUTH_CONTEXT', SPID_ACR_L1
+)
+
+settings.SPID_ACR_FAUTHN_MAP = getattr(
+    settings, 'SPID_ACR_FAUTHN_MAP',
+    {
+        SPID_ACR_L1 : 'false',
+        SPID_ACR_L2 : 'true',
+        SPID_ACR_L3 : 'true'
+    }
 )
 
 settings.SPID_CERTS_DIR = getattr(

--- a/src/djangosaml2_spid/spid_request.py
+++ b/src/djangosaml2_spid/spid_request.py
@@ -49,7 +49,7 @@ def spid_sp_authn_request(conf, selected_idp, next_url=''):
     authn_req.requested_authn_context = authn_context
 
     # if SPID authentication level is > 1 then forceauthn must be True
-    authn_req.force_authn = 'true'
+    authn_req.force_authn = settings.SPID_ACR_FAUTHN_MAP[settings.SPID_AUTH_CONTEXT]
 
     authn_req.protocol_binding = SAML2_DEFAULT_BINDING
 


### PR DESCRIPTION
* feat: added settings.SPID_ACR_FAUTHN_MAP

````
settings.SPID_ACR_FAUTHN_MAP = getattr(
    settings, 'SPID_ACR_FAUTHN_MAP',
    {
        SPID_ACR_L1 : 'false',
        SPID_ACR_L2 : 'true',
        SPID_ACR_L3 : 'true'
    }
)
````

linked to this:
https://github.com/italia/spid-sp-test/issues/44

spid-sp-test will be patch in the next release