### PR TITLE
Adapt app templates to layout rules

### DIFF
--- a/src/djangosaml2_spid/templates/spid_base.html
+++ b/src/djangosaml2_spid/templates/spid_base.html
@@ -9,9 +9,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <!-- Page details -->
 
-        <title>
-            Accedi Con SPID
-        </title>
+        {% block page_title %}{% endblock page_title %}
 
         <meta name="description" content="Bootstrap Italia">
         <!-- CSS -->

--- a/src/djangosaml2_spid/templates/spid_login_error.html
+++ b/src/djangosaml2_spid/templates/spid_login_error.html
@@ -1,20 +1,24 @@
 {% extends 'spid_base.html' %}
+
+{% load i18n %}
 {% load static %}
 
+{% block page_title %}
+    <title>
+        {% trans "Error" %}
+    </title>
+{% endblock page_title %}
+
 {% block container %}
-<div class="card-wrapper card-space">
-    <div class="card card-bg no-after">
-        <div class="card-body">
-            <div class="row">
-                <h2>Errore di autenticazione</h2>
-            </div>
-            <div class="row">
-                <h3>{{ spid_anomaly.message|default:'Accesso negato' }}</h3>
-            </div>
-            <div class="row">
-                <h4>{{ spid_anomaly.troubleshoot|default:'' }}</h4>
-            </div>
+    <div class="callout danger">
+        <div class="callout-title">
+            Errore di autenticazione
         </div>
+        <p>
+            <p>{{ spid_anomaly.message|default:'Accesso negato' }}</p>
+            {% if spid_anomaly.troubleshoot %}
+                <p>{{ spid_anomaly.troubleshoot|default:'' }}</p>
+            {% endif %}
+        </p>
     </div>
-</div>
 {% endblock %}

--- a/src/djangosaml2_spid/templates/wayf.html
+++ b/src/djangosaml2_spid/templates/wayf.html
@@ -1,6 +1,12 @@
 {% extends 'spid_base.html' %}
 {% load spid static %}
 
+{% block page_title %}
+    <title>
+        Accedi Con SPID
+    </title>
+{% endblock page_title %}
+
 {% block extra_head %}
 <script type="text/javascript" src="{% static 'spid/brython.js' %}"></script>
 <!-- Useful only if urllib is needed ...
@@ -64,7 +70,7 @@
 
 <a href="#" class="italia-it-button italia-it-button-size-xl button-spid" spid-idp-button="#spid-idp-button-xlarge-post" aria-haspopup="true" aria-expanded="false">
     <span class="italia-it-button-icon"><img src="{% static 'spid/spid-ico-circle-bb.svg' %}" onerror="this.src='img/spid-ico-circle-bb.png'; this.onerror=null;" alt=""></span>
-    <span class="italia-it-button-text">SPID</span>
+    <span class="italia-it-button-text">Entra con SPID</span>
 </a>
 <div id="spid-idp-button-xlarge-post" class="spid-idp-button spid-idp-button-tip spid-idp-button-relative">
     <ul id="spid-idp-list-medium-root-get" class="spid-idp-button-menu" aria-labelledby="spid-idp">


### PR DESCRIPTION
  - Add `page_title` block and customize title in each page
  - Adapt button text in _wayf.html_
  - Modify container block in _spid_login_error.html_