### PR TITLE
Fix in_response_to parameter check in Saml2ResponseValidator

### DIFF
--- a/src/djangosaml2_spid/spid_validator.py
+++ b/src/djangosaml2_spid/spid_validator.py
@@ -35,12 +35,21 @@ class Saml2ResponseValidator(object):
 
     # handled adding authn req arguments in the session state (cookie)
     def validate_in_response_to(self):
-        """ spid test 18
+        """ spid test 16, 17 e 18
         """
-        if self.in_response_to:
-            if self.in_response_to != self.response.in_response_to:
-                raise SpidError(f'In response To not valid: '
-                                f'{self.in_response_to} != {self.response.in_response_to}')
+        if not self.response.in_response_to:
+            if self.response.in_response_to is None:
+                raise SpidError('InResponseTo not provided')  # Error nr.17
+            raise SpidError('InResponseTo unspecified')  # Error nr.16
+
+        # Check for error nr.18
+        if isinstance(self.in_response_to, str):
+            if self.response.in_response_to != self.in_response_to:
+                raise SpidError(f'InResponseTo not valid: '
+                                f'{self.response.in_response_to} != {self.in_response_to}')
+        elif self.response.in_response_to not in self.in_response_to:
+            raise SpidError(f'InResponseTo not valid: '
+                            f'{self.response.in_response_to} not in {self.in_response_to}')
 
     def validate_destination(self):
         """ spid test 19 e 20

--- a/src/djangosaml2_spid/spid_validator.py
+++ b/src/djangosaml2_spid/spid_validator.py
@@ -71,12 +71,13 @@ class Saml2ResponseValidator(object):
                     f'Issuer different {self.response.issuer.text}'
                 )
 
-        # 30
+        # 30, 31
         # check that this issuer is in the metadata...
-        if self.response.issuer.text != "urn:oasis:names:tc:SAML:2.0:nameid-format:entity":
-            raise SpidError(
-                f'Issuer NameFormat is invalid: {self.requester} != {self.response.issuer.text}'
-        )
+        if self.response.issuer.format:
+            if self.response.issuer.format != "urn:oasis:names:tc:SAML:2.0:nameid-format:entity":
+                raise SpidError(
+                    f'Issuer NameFormat is invalid: {self.response.issuer.format} != "urn:oasis:names:tc:SAML:2.0:nameid-format:entity"'
+            )
 
         msg = 'Issuer format is not valid: {}'
         # 70, 71

--- a/src/djangosaml2_spid/views.py
+++ b/src/djangosaml2_spid/views.py
@@ -326,13 +326,9 @@ class AssertionConsumerServiceView(djangosaml2_views.AssertionConsumerServiceVie
         recipient = conf._sp_endpoints['assertion_consumer_service'][0][0]
         authn_context_classref = settings.SPID_AUTH_CONTEXT
         
-        in_response_to = ''
         oq_cache = OutstandingQueriesCache(self.request.saml_session)
-        logger.debug("Cache queries: {}".format(oq_cache.outstanding_queries()))
-        for key, _value in oq_cache.outstanding_queries().items():
-            in_response_to = key
-            logger.debug("in_response_to={!r}".format(in_response_to))
-            break
+        in_response_to = oq_cache.outstanding_queries()
+        logger.debug("in_response_to=%r", in_response_to)
 
         validator = Saml2ResponseValidator(authn_response=response.xmlstr,
                                            recipient=recipient,


### PR DESCRIPTION
  - Provide `in_response_to` with the outstanding queries cache in `AssertionConsumerServiceView.custom_validation()`
  - `Saml2ResponseValidator.validate_in_response_to()`: checks also errors nr.16 and nr.17
  - instance attribute `in_response_to` can be also a container (dict) that refers to a set of IDs