### PR TITLE
Add alternative settings for running the demo project

### DIFF
--- a/example/example/develop_settings.py
+++ b/example/example/develop_settings.py
@@ -1,0 +1,9 @@
+#
+# Settings file for running the demo projects with Django's development server.
+#
+# noinspection PyUnresolvedReferences
+from .settings import *
+
+SESSION_COOKIE_SECURE = False  # Allows the sent of session cookie on http
+CSRF_COOKIE_SECURE = False     # Allows the sent of csrf cookie on http
+SPID_BASE_URL = None           # the base URL is got dynamically from request.build_absolute_uri('/')

--- a/example/example/dynamic_settings.py
+++ b/example/example/dynamic_settings.py
@@ -1,0 +1,8 @@
+#
+# Settings file for running the demo projects with dynamic base URL setting.
+# Useful for running the demo with a non-local IP address.
+#
+# noinspection PyUnresolvedReferences
+from .settings import *
+
+SPID_BASE_URL = None  # With None the base URL is got dynamically from request.build_absolute_uri('/')

--- a/example/run.sh
+++ b/example/run.sh
@@ -1,5 +1,56 @@
-python -B ./manage.py migrate
-python -B ./manage.py collectstatic --noinput
+#!/usr/bin/env bash
+# 
+# Run the demo project with uwsgi web server (https, the default) or the development server (http)
+#  
 
-# python -B ./manage.py runserver 0.0.0.0:8000
-uwsgi --http-keepalive  --https 0.0.0.0:8000,./certificates/public.cert,./certificates/private.key --module example.wsgi:application --env example.settings --chdir .
+# Default run settings
+address="0.0.0.0:8000"
+protocol="https"
+
+# Parse cli arguments provided with -p PROTOCOL or -a ADDRESS (take the lasts)
+while getopts p:a: flag
+do
+    case "${flag}" in
+        p) protocol=${OPTARG};;
+        a) address=${OPTARG};;
+    esac
+done
+
+# Select and run the proper server and settings
+if [[ $protocol = "http" ]]
+then
+  echo "Run on http with Django's development server ..."
+  python -B ./manage.py migrate
+  DJANGO_SETTINGS_MODULE='example.develop_settings' python -B ./manage.py runserver $address
+
+elif [[ $protocol != "https" ]]
+then
+  echo -e "\033[1;31mWrong protocol '$protocol' provided (use 'https' or 'http').\033[0m"
+  exit 1
+
+elif [[ $address != "0.0.0.0:8000" ]]
+then
+  echo "Run on https with uwsgi server and dynamic SPID_BASE_URL ..."
+  python -B ./manage.py migrate
+  python -B ./manage.py collectstatic --noinput
+
+  DJANGO_SETTINGS_MODULE='example.dynamic_settings' uwsgi \
+    --http-keepalive \
+    --https $address,./certificates/public.cert,./certificates/private.key \
+    --module example.wsgi:application \
+    --env example.dynamic_settings \
+    --chdir .
+
+else
+  echo "Run on https with uwsgi server and fixed SPID_BASE_URL ..."
+  python -B ./manage.py migrate
+  python -B ./manage.py collectstatic --noinput
+
+  uwsgi \
+    --http-keepalive \
+    --https 0.0.0.0:8000,./certificates/public.cert,./certificates/private.key \
+    --module example.wsgi:application \
+    --env example.settings \
+    --chdir .
+
+fi


### PR DESCRIPTION
  - add new file `example/develop_settings.py`
  - add new file `example/dynamic_settings.py`
  - modify the `run.sh` script: keep the current behavior for default
    but the demo can also be run with dynamic `SPID_BASE_URL` and the
    runserver providing `-p PROTOCOL` and/or `-a ADDRESS` options.