### PR TITLE
Add templates for importing the SPID button and its scripts

### DIFF
--- a/src/djangosaml2_spid/templates/spid_base.html
+++ b/src/djangosaml2_spid/templates/spid_base.html
@@ -18,8 +18,6 @@
 
         <link rel="shortcut icon" href="{% static 'spid/favicon/favicon-32x32.png' %}">
 
-        <link type="text/css" rel="stylesheet" href="{% static 'spid/spid-sp-access-button.css' %}">
-
         {% block extra_head %} {%  endblock %}
 
     </head>
@@ -352,9 +350,6 @@ lorem ipsum
 
         <script>window.__PUBLIC_PATH__ = "{%  static 'spid/fonts' %}"</script>
         <script src="{% static 'spid/bootstrap-italia.js' %}"></script>
-
-        <script src="{% static 'spid/spid-sp-access-button.js' %}"></script>
-        <script src="{% static 'spid/spid_button.js' %}"></script>
 
         {% block extra_scripts %} {%  endblock %}
 

--- a/src/djangosaml2_spid/templates/spid_button.html
+++ b/src/djangosaml2_spid/templates/spid_button.html
@@ -1,0 +1,55 @@
+{% comment %}
+Template with AGID - SPID button
+Parameter:
+  size: ('s'|'m'|'l'|'xl')
+{% endcomment %}
+{% load static spid %}
+
+<!-- AGID - SPID SP/IDP BUTTON "ENTRA CON SPID" * begin * -->
+<a href="{{ href|default:'#' }}" class="italia-it-button italia-it-button-size-{{ size }} button-spid"
+   spid-idp-button="#spid-idp-button-{{ size|spid_button_size }}-post" aria-haspopup="true" aria-expanded="false">
+    <span class="italia-it-button-icon"><img src="{% static 'spid/spid-ico-circle-bb.svg' %}" onerror="this.src='img/spid-ico-circle-bb.png'; this.onerror=null;" alt=""></span>
+    <span class="italia-it-button-text">Entra con SPID</span>
+</a>
+
+<div id="spid-idp-button-{{ size|spid_button_size }}-post" class="spid-idp-button spid-idp-button-tip spid-idp-button-relative">
+  <ul id="spid-idp-list-medium-root-get" class="spid-idp-button-menu" aria-labelledby="spid-idp">
+    <li class="spid-idp-button-link" id="spid_saml_check" data-idp="spid_saml_check" data-entityid="{% spid_saml_check_url %}">
+        <a href="#"><span class="spid-sr-only">SPID-saml-check</span><img src="" onerror="this.src=''; this.onerror=null;" alt="Spid saml check"></a>
+    </li>
+    <li class="spid-idp-button-link" id="spid_testenv2" data-idp="spid_testenv2" data-entityid="{% spid_testenv2_url %}">
+        <a href="#"><span class="spid-sr-only">SPID-testenv2</span><img src="" onerror="this.src=''; this.onerror=null;" alt="Spid test env2"></a>
+    </li>
+    <li class="spid-idp-button-link" id="spid_validator" data-idp="spid_validator" data-entityid="https://validator.spid.gov.it">
+        <a href="#"><span class="spid-sr-only">SPID-Validator</span><img src="" onerror="this.src=''; this.onerror=null;" alt="Spid Validator"></a>
+    </li>
+
+    <li class="spid-idp-button-link" id="spiditalia" data-idp="spiditalia" data-entityid="https://spid.register.it">
+        <a href="#"><span class="spid-sr-only">SPIDItalia Register.it</span><img src="{% static 'spid/spid-idp-spiditalia.svg' %}" onerror="this.src='{% static 'spid/spid-idp-spiditalia.svg' %}'; this.onerror=null;" alt="SPIDItalia Register.it"></a>
+    </li>
+    <li class="spid-idp-button-link" id="timid" data-idp="timid" data-entityid="https://login.id.tim.it/affwebservices/public/saml2sso">
+        <a href="#"><span class="spid-sr-only">Tim ID</span><img src="{% static 'spid/spid-idp-timid.svg' %}" onerror="this.src='{% static 'spid/spid-idp-timid.svg' %}'; this.onerror=null;" alt="Tim ID"></a>
+    </li><li class="spid-idp-button-link" id="intesaid" data-idp="intesaid" data-entityid="https://spid.intesa.it">
+        <a href="#"><span class="spid-sr-only">Intesa ID</span><img src="{% static 'spid/spid-idp-intesaid.svg' %}" onerror="this.src='{% static 'spid/spid-idp-intesaid.svg' %}; this.onerror=null;" alt="Intesa ID"></a>
+    </li><li class="spid-idp-button-link" id="posteid" data-idp="posteid" data-entityid="https://posteid.poste.it">
+        <a href="#"><span class="spid-sr-only">Poste ID</span><img src="{% static 'spid/spid-idp-posteid.svg' %}" onerror="this.src='{% static 'spid/spid-idp-posteid.svg' %}'; this.onerror=null;" alt="Poste ID"></a>
+    </li><li class="spid-idp-button-link" id="arubaid" data-idp="arubaid" data-entityid="https://loginspid.aruba.it">
+        <a href="#"><span class="spid-sr-only">Aruba ID</span><img src="{% static 'spid/spid-idp-arubaid.svg' %}" onerror="this.src='{% static 'spid/spid-idp-arubaid.svg' %}'; this.onerror=null;" alt="Aruba ID"></a>
+    </li><li class="spid-idp-button-link" id="lepidaid" data-idp="lepidaid" data-entityid="https://id.lepida.it/idp/shibboleth">
+        <a href="#"><span class="spid-sr-only">Lepida ID</span><img src="{% static 'spid/spid-idp-lepidaid.svg' %}" onerror="this.src='{% static 'spid/spid-idp-lepidaid.svg' %}'; this.onerror=null;" alt="Lepida ID"></a>
+    </li><li class="spid-idp-button-link" id="infocertid" data-idp="infocertid" data-entityid="https://identity.infocert.it">
+        <a href="#"><span class="spid-sr-only">Infocert ID</span><img src="{% static 'spid/spid-idp-infocertid.svg' %}" onerror="this.src='{% static 'spid/spid-idp-infocertid.svg' %}'; this.onerror=null;" alt="Infocert ID"></a>
+    </li><li class="spid-idp-button-link" id="namirialid" data-idp="namirialid" data-entityid="https://idp.namirialtsp.com/idp">
+        <a href="#"><span class="spid-sr-only">Namirial ID</span><img src="{% static 'spid/spid-idp-namirialid.svg' %}" onerror="this.src='{% static 'spid/spid-idp-namirialid.svg' %}'; this.onerror=null;" alt="Namirial ID"></a>
+    </li><li class="spid-idp-button-link" id="sielteid" data-idp="sielteid" data-entityid="https://identity.sieltecloud.it">
+        <a href="#"><span class="spid-sr-only">Sielte ID</span><img src="{% static 'spid/spid-idp-sielteid.svg' %}" onerror="this.src='{% static 'spid/spid-idp-sielteid.svg' %}'; this.onerror=null;" alt="Sielte ID"></a>
+    </li><li class="spid-idp-support-link">
+        <a href="https://www.spid.gov.it/">Maggiori informazioni</a>
+    </li><li class="spid-idp-support-link">
+        <a href="https://www.spid.gov.it/richiedi-spid">Non hai SPID?</a>
+    </li><li class="spid-idp-support-link">
+        <a href="https://www.spid.gov.it/serve-aiuto">Serve aiuto?</a>
+    </li>
+  </ul>
+</div>
+<!-- AGID - SPID IDP BUTTON "ENTRA CON SPID" * end * -->

--- a/src/djangosaml2_spid/templates/spid_button_scripts.html
+++ b/src/djangosaml2_spid/templates/spid_button_scripts.html
@@ -1,0 +1,39 @@
+{% comment %}
+Template with SPID button scripts, that have to be included before <body> ending.
+{% endcomment %}
+{% load static %}
+
+<script type="text/javascript" src="{% static 'spid/brython.js' %}"></script>
+<script type="text/javascript">
+    // brython init
+    document.addEventListener('DOMContentLoaded', function() {
+        brython({debug: 1});
+    }, false);
+</script>
+
+<script type="text/python">
+    import browser
+
+    debug = 1
+
+    def disco(ev):
+        if debug: browser.console.log(ev.__dict__)
+        if not hasattr(ev.currentTarget.dataset, 'entityid'):
+            browser.alert('dataset not found:\n please add \"data-entityid="$variable"\" to element ')
+            return
+        entity_id = ev.currentTarget.dataset.entityid
+        if debug: browser.console.log(entity_id)
+        # browser.console.log(args)
+        # dest = browser.window.location.pathname + '?idp={}'.format(entity_id)
+        dest = '/spid/login/?idp={}'.format(entity_id)
+        browser.console.log(dest)
+        browser.window.location = dest
+
+    # spid buttons event on click
+    for ele in browser.document.select("li.spid-idp-button-link"):
+        ele.bind("click", disco)
+
+</script>
+
+<script src="{% static 'spid/spid-sp-access-button.js' %}"></script>
+<script src="{% static 'spid/spid_button.js' %}"></script>

--- a/src/djangosaml2_spid/templates/wayf.html
+++ b/src/djangosaml2_spid/templates/wayf.html
@@ -8,46 +8,8 @@
 {% endblock page_title %}
 
 {% block extra_head %}
-<script type="text/javascript" src="{% static 'spid/brython.js' %}"></script>
-
-<script type="text/javascript">
-    // brython init
-    document.addEventListener('DOMContentLoaded', function() {
-        brython({debug: 1});
-    }, false);
-</script>
-
-<script type="text/python">
-    import browser
-
-    debug = 1
-
-    def disco(ev):
-        if debug: browser.console.log(ev.__dict__)
-        if not hasattr(ev.currentTarget.dataset, 'entityid'):
-            browser.alert('dataset not found:\n please add \"data-entityid="$variable"\" to element ')
-            return
-        entity_id = ev.currentTarget.dataset.entityid
-        if debug: browser.console.log(entity_id)
-        # browser.console.log(args)
-        dest = browser.window.location.pathname + '?idp={}'.format(entity_id)
-        browser.console.log(dest)
-        browser.window.location = dest
-
-    # something like:
-    # {entityID: "https://satosa.testunical.it/Saml2/metadata",
-    #  return: "https://satosa.testunical.it/Saml2/disco"}
-    # args = get_args()
-    # if debug: browser.console.log(args)
-
-    # other_idp_ID button event on click
-    # browser.document["custon_idp_id"].bind("click", disco)
-
-    # spid buttons event on click
-    for ele in browser.document.select("li.spid-idp-button-link"):
-        ele.bind("click", disco)
-</script>
-{%  endblock %}
+        <link type="text/css" rel="stylesheet" href="{% static 'spid/spid-sp-access-button.css' %}">
+{% endblock extra_head %}
 
 {% block container %}
 <div class="col-12 py-md-5 bd-content">
@@ -63,51 +25,7 @@
         <div class="card-body">
             <div class="row">
                 <div class="col-sm text-center">
-                    <!-- AGID - SPID IDP BUTTON SMALL "ENTRA CON SPID" * begin * -->
-
-<a href="#" class="italia-it-button italia-it-button-size-xl button-spid" spid-idp-button="#spid-idp-button-xlarge-post" aria-haspopup="true" aria-expanded="false">
-    <span class="italia-it-button-icon"><img src="{% static 'spid/spid-ico-circle-bb.svg' %}" onerror="this.src='img/spid-ico-circle-bb.png'; this.onerror=null;" alt=""></span>
-    <span class="italia-it-button-text">Entra con SPID</span>
-</a>
-<div id="spid-idp-button-xlarge-post" class="spid-idp-button spid-idp-button-tip spid-idp-button-relative">
-    <ul id="spid-idp-list-medium-root-get" class="spid-idp-button-menu" aria-labelledby="spid-idp">
-
-        <li class="spid-idp-button-link" id="spid_saml_check" data-idp="spid_saml_check" data-entityid="{% spid_saml_check_url %}">
-            <a href="#"><span class="spid-sr-only">SPID-saml-check</span><img src="" onerror="this.src=''; this.onerror=null;" alt="Spid saml check"></a>
-        </li>
-        <li class="spid-idp-button-link" id="spid_testenv2" data-idp="spid_testenv2" data-entityid="{% spid_testenv2_url %}">
-            <a href="#"><span class="spid-sr-only">SPID-testenv2</span><img src="" onerror="this.src=''; this.onerror=null;" alt="Spid test env2"></a>
-        </li>
-
-        <li class="spid-idp-button-link" id="spiditalia" data-idp="spiditalia" data-entityid="https://spid.register.it">
-            <a href="#"><span class="spid-sr-only">SPIDItalia Register.it</span><img src="{% static 'spid/spid-idp-spiditalia.svg' %}" onerror="this.src='{% static 'spid/spid-idp-spiditalia.svg' %}'; this.onerror=null;" alt="SPIDItalia Register.it"></a>
-        </li>
-        <li class="spid-idp-button-link" id="timid" data-idp="timid" data-entityid="https://login.id.tim.it/affwebservices/public/saml2sso">
-            <a href="#"><span class="spid-sr-only">Tim ID</span><img src="{% static 'spid/spid-idp-timid.svg' %}" onerror="this.src='{% static 'spid/spid-idp-timid.svg' %}'; this.onerror=null;" alt="Tim ID"></a>
-        </li><li class="spid-idp-button-link" id="intesaid" data-idp="intesaid" data-entityid="https://spid.intesa.it">
-            <a href="#"><span class="spid-sr-only">Intesa ID</span><img src="{% static 'spid/spid-idp-intesaid.svg' %}" onerror="this.src='{% static 'spid/spid-idp-intesaid.svg'; this.onerror=null;" alt="Intesa ID"></a>
-        </li><li class="spid-idp-button-link" id="posteid" data-idp="posteid" data-entityid="https://posteid.poste.it">
-            <a href="#"><span class="spid-sr-only">Poste ID</span><img src="{% static 'spid/spid-idp-posteid.svg' %}" onerror="this.src='{% static 'spid/spid-idp-posteid.svg' %}'; this.onerror=null;" alt="Poste ID"></a>
-        </li><li class="spid-idp-button-link" id="arubaid" data-idp="arubaid" data-entityid="https://loginspid.aruba.it">
-            <a href="#"><span class="spid-sr-only">Aruba ID</span><img src="{% static 'spid/spid-idp-arubaid.svg' %}" onerror="this.src='{% static 'spid/spid-idp-arubaid.svg' %}'; this.onerror=null;" alt="Aruba ID"></a>
-        </li><li class="spid-idp-button-link" id="lepidaid" data-idp="lepidaid" data-entityid="https://id.lepida.it/idp/shibboleth">
-            <a href="#"><span class="spid-sr-only">Lepida ID</span><img src="{% static 'spid/spid-idp-lepidaid.svg' %}" onerror="this.src='{% static 'spid/spid-idp-lepidaid.svg' %}'; this.onerror=null;" alt="Lepida ID"></a>
-        </li><li class="spid-idp-button-link" id="infocertid" data-idp="infocertid" data-entityid="https://identity.infocert.it">
-            <a href="#"><span class="spid-sr-only">Infocert ID</span><img src="{% static 'spid/spid-idp-infocertid.svg' %}" onerror="this.src='{% static 'spid/spid-idp-infocertid.svg' %}'; this.onerror=null;" alt="Infocert ID"></a>
-        </li><li class="spid-idp-button-link" id="namirialid" data-idp="namirialid" data-entityid="https://idp.namirialtsp.com/idp">
-            <a href="#"><span class="spid-sr-only">Namirial ID</span><img src="{% static 'spid/spid-idp-namirialid.svg' %}" onerror="this.src='{% static 'spid/spid-idp-namirialid.svg' %}'; this.onerror=null;" alt="Namirial ID"></a>
-        </li><li class="spid-idp-button-link" id="sielteid" data-idp="sielteid" data-entityid="https://identity.sieltecloud.it">
-            <a href="#"><span class="spid-sr-only">Sielte ID</span><img src="{% static 'spid/spid-idp-sielteid.svg' %}" onerror="this.src='{% static 'spid/spid-idp-sielteid.svg' %}'; this.onerror=null;" alt="Sielte ID"></a>
-        </li><li class="spid-idp-support-link">
-            <a href="https://www.spid.gov.it/">Maggiori informazioni</a>
-        </li><li class="spid-idp-support-link">
-            <a href="https://www.spid.gov.it/richiedi-spid">Non hai SPID?</a>
-        </li><li class="spid-idp-support-link">
-            <a href="https://www.spid.gov.it/serve-aiuto">Serve aiuto?</a>
-        </li></ul>
-</div>
-<!-- AGID - SPID IDP BUTTON SMALL "ENTRA CON SPID" * end * -->
-
+                    {% include 'spid_button.html' with size='xl' %}
                 </div>
             </div>
         </div>
@@ -116,3 +34,7 @@
 
 </div>
 {% endblock %}
+
+{% block extra_scripts %}
+    {% include 'spid_button_scripts.html' %}
+{% endblock extra_scripts %}

--- a/src/djangosaml2_spid/templatetags/spid.py
+++ b/src/djangosaml2_spid/templatetags/spid.py
@@ -15,3 +15,17 @@ def spid_saml_check_url():
 def spid_testenv2_url():
     url = urlparse(settings.SPID_TESTENV2_METADATA_URL)
     return f'{url.scheme}://{url.netloc}'
+
+
+@register.filter()
+def spid_button_size(size):
+    if size in {'short', 'medium', 'large', 'xlarge'}:
+        return size
+    elif size == 's':
+        return 'small'
+    elif size == 'm':
+        return 'medium'
+    elif size == 'xl':
+        return 'xlarge'
+    else:
+        return 'large'


### PR DESCRIPTION
This PR has the target of simplifying the SPID button inclusion in other templates:

  - Import where the SPID button is needed and with a parameter size=('s'|'m'|'l'|'xl')
  - Import scripts required for SPID button at the end of the page
  - Add template filter spid_button_size