### PR TITLE
Change test IdP settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ To run the demo project:
  - python -B ./manage.py collectstatic --noinput
  - uwsgi --https 0.0.0.0:8000,./certificates/public.cert,./certificates/private.key --module example.wsgi:application --env example.settings --chdir .
 
-or execute the run.sh script with these environment settings to enable tests idps:
+or execute the run.sh script with these environment settings to enable tests IdPs:
 
  ````
- SPID_SAML_CHECK_REMOTE_METADATA_ACTIVE=True SPID_SAML_CHECK_DEMO_METADATA_ACTIVE=True bash run.sh
+ SPID_SAML_CHECK_IDP_ACTIVE=True SPID_DEMO_IDP_ACTIVE=True bash run.sh
  ````
 
-If you choosed to use *spid-testenv2*, before starting it, you just have to save the
+If you chose to use *spid-testenv2*, before starting it, you just have to save the
 current demo metadata in *spid-testenv2* configuration, this way:
 
 ````

--- a/example/spid_config/spid_settings.py
+++ b/example/spid_config/spid_settings.py
@@ -33,11 +33,11 @@ SPID_PRIVATE_KEY = os.path.join(SPID_CERTS_DIR, 'private.key')
 SPID_IDENTITY_PROVIDERS_URL = 'https://registry.spid.gov.it/assets/data/idp.json'
 SPID_IDENTITY_PROVIDERS_METADATA_DIR = os.path.join(BASE_DIR, 'spid_config/metadata/')
 
-SPID_SAML_CHECK_REMOTE_METADATA_ACTIVE = os.environ.get('SPID_SAML_CHECK_REMOTE_METADATA_ACTIVE', 'False') == 'True'
+SPID_SAML_CHECK_IDP_ACTIVE = os.environ.get('SPID_SAML_CHECK_IDP_ACTIVE', 'False') == 'True'
 SPID_SAML_CHECK_METADATA_URL = os.environ.get('SPID_SAML_CHECK_METADATA_URL', 'http://localhost:8080/metadata.xml')
 
-SPID_SAML_CHECK_DEMO_REMOTE_METADATA_ACTIVE = os.environ.get('SPID_SAML_CHECK_DEMO_REMOTE_METADATA_ACTIVE', 'False') == 'True'
-SPID_SAML_CHECK_DEMO_METADATA_URL = os.environ.get('SPID_SAML_CHECK_DEMO_METADATA_URL', 'http://localhost:8080/demo/metadata.xml')
+SPID_DEMO_IDP_ACTIVE = os.environ.get('SPID_DEMO_IDP_ACTIVE', 'False') == 'True'
+SPID_DEMO_METADATA_URL = os.environ.get('SPID_DEMO_METADATA_URL', 'http://localhost:8080/demo/metadata.xml')
 
 # Avviso 29v3
 SPID_PREFIXES = dict(

--- a/src/djangosaml2_spid/conf.py
+++ b/src/djangosaml2_spid/conf.py
@@ -117,11 +117,16 @@ settings.SPID_IDENTITY_PROVIDERS_METADATA_DIR = getattr(
 )
 
 # Validation tools settings
-settings.SPID_SAML_CHECK_REMOTE_METADATA_ACTIVE = getattr(
-    settings,
-    'SPID_SAML_CHECK_REMOTE_METADATA_ACTIVE',
-    os.environ.get('SPID_SAML_CHECK_REMOTE_METADATA_ACTIVE', 'False') == 'True'
-)
+if hasattr(settings, 'SPID_SAML_CHECK_IDP_ACTIVE'):
+    pass
+elif 'SPID_SAML_CHECK_IDP_ACTIVE' in os.environ:
+    settings.SPID_SAML_CHECK_IDP_ACTIVE = os.environ['SPID_SAML_CHECK_IDP_ACTIVE'] == 'True'
+else:
+    # Checks the old setting name
+    settings.SPID_SAML_CHECK_IDP_ACTIVE = getattr(
+        settings, 'SPID_SAML_CHECK_REMOTE_METADATA_ACTIVE',
+        os.environ.get('SPID_SAML_CHECK_REMOTE_METADATA_ACTIVE', 'False') == 'True'
+    )
 
 settings.SPID_SAML_CHECK_METADATA_URL = getattr(
     settings,
@@ -129,16 +134,24 @@ settings.SPID_SAML_CHECK_METADATA_URL = getattr(
     os.environ.get('SPID_SAML_CHECK_METADATA_URL', 'http://localhost:8080/metadata.xml')
 )
 
-settings.SPID_SAML_CHECK_DEMO_REMOTE_METADATA_ACTIVE = getattr(
+settings.SPID_DEMO_IDP_ACTIVE = getattr(
     settings,
-    'SPID_SAML_CHECK_DEMO_REMOTE_METADATA_ACTIVE',
-    os.environ.get('SPID_SAML_CHECK_DEMO_REMOTE_METADATA_ACTIVE', 'False') == 'True'
+    'SPID_DEMO_ACTIVE',
+    os.environ.get('SPID_DEMO_ACTIVE', 'False') == 'True'
 )
 
-settings.SPID_SAML_CHECK_DEMO_METADATA_URL = getattr(
+settings.SPID_DEMO_METADATA_URL = getattr(
     settings,
-    'SPID_SAML_CHECK_DEMO_METADATA_URL',
-    os.environ.get('SPID_SAML_CHECK_DEMO_METADATA_URL', 'https://demo.spid.gov.it/metadata.xml')
+    'SPID_DEMO_METADATA_URL',
+    os.environ.get('SPID_DEMO_METADATA_URL', 'https://demo.spid.gov.it/metadata.xml')
+)
+
+settings.SPID_VALIDATOR_IDP_ACTIVE = getattr(
+    settings, 'SPID_VALIDATOR_ACTIVE', False
+)
+
+settings.SPID_VALIDATOR_METADATA_URL = getattr(
+    settings, 'SPID_VALIDATOR_METADATA_URL', 'https://validator.spid.gov.it'
 )
 
 # Avviso 29v3
@@ -308,14 +321,19 @@ def config_settings_loader(request: Optional[HttpRequest] = None) -> SPConfig:
             ['/opt/local/bin', '/usr/bin/xmlsec1']
         )
 
-    if settings.SPID_SAML_CHECK_REMOTE_METADATA_ACTIVE:
+    if settings.SPID_SAML_CHECK_IDP_ACTIVE:
         saml_config['metadata']['remote'].append(
             {'url': settings.SPID_SAML_CHECK_METADATA_URL}
         )
 
-    if settings.SPID_SAML_CHECK_REMOTE_METADATA_ACTIVE:
+    if settings.SPID_DEMO_IDP_ACTIVE:
         saml_config['metadata']['remote'].append(
-            {'url': settings.SPID_SAML_CHECK_REMOTE_METADATA_ACTIVE}
+            {'url': settings.SPID_DEMO_METADATA_URL}
+        )
+
+    if settings.SPID_VALIDATOR_IDP_ACTIVE:
+        saml_config['metadata']['remote'].append(
+            {'url': settings.SPID_VALIDATOR_METADATA_URL}
         )
 
     logger.debug(f'SAML_CONFIG: {saml_config}')

--- a/src/djangosaml2_spid/templates/spid_button.html
+++ b/src/djangosaml2_spid/templates/spid_button.html
@@ -14,16 +14,21 @@ Parameter:
 
 <div id="spid-idp-button-{{ size|spid_button_size }}-post" class="spid-idp-button spid-idp-button-tip spid-idp-button-relative">
   <ul id="spid-idp-list-medium-root-get" class="spid-idp-button-menu" aria-labelledby="spid-idp">
+    {% if spid_saml_check_idp_active %}
     <li class="spid-idp-button-link" id="spid_saml_check" data-idp="spid_saml_check" data-entityid="{% spid_saml_check_url %}">
         <a href="#"><span class="spid-sr-only">SPID-saml-check</span><img src="" onerror="this.src=''; this.onerror=null;" alt="Spid saml check"></a>
     </li>
-    <li class="spid-idp-button-link" id="spid_saml_check_demo_idp" data-idp="spid_saml_check_demo_idp" data-entityid="{% spid_saml_check_demo_url %}">
+    {% endif %}
+    {% if spid_demo_idp_active %}
+    <li class="spid-idp-button-link" id="spid_demo" data-idp="spid_demo" data-entityid="{% spid_demo_url %}">
         <a href="#"><span class="spid-sr-only">SPID-saml-check Demo IdP</span><img src="" onerror="this.src=''; this.onerror=null;" alt="Spid saml check demo IdP"></a>
     </li>
-    <li class="spid-idp-button-link" id="spid_validator" data-idp="spid_validator" data-entityid="https://validator.spid.gov.it">
+    {% endif %}
+    {% if spid_validator_idp_active %}
+    <li class="spid-idp-button-link" id="spid_validator" data-idp="spid_validator" data-entityid="{% spid_validator_url %}">
         <a href="#"><span class="spid-sr-only">SPID-Validator</span><img src="" onerror="this.src=''; this.onerror=null;" alt="Spid Validator"></a>
     </li>
-
+    {% endif %}
     <li class="spid-idp-button-link" id="spiditalia" data-idp="spiditalia" data-entityid="https://spid.register.it">
         <a href="#"><span class="spid-sr-only">SPIDItalia Register.it</span><img src="{% static 'spid/spid-idp-spiditalia.svg' %}" onerror="this.src='{% static 'spid/spid-idp-spiditalia.svg' %}'; this.onerror=null;" alt="SPIDItalia Register.it"></a>
     </li>

--- a/src/djangosaml2_spid/templatetags/spid.py
+++ b/src/djangosaml2_spid/templatetags/spid.py
@@ -6,15 +6,36 @@ register = template.Library()
 
 
 @register.simple_tag()
+def spid_saml_check_idp_active():
+    return settings.SPID_SAML_CHECK_IDP_ACTIVE
+
+
+@register.simple_tag()
 def spid_saml_check_url():
     url = urlparse(settings.SPID_SAML_CHECK_METADATA_URL)
     return f'{url.scheme}://{url.netloc}'
 
 
 @register.simple_tag()
-def spid_saml_check_demo_url():
-    url = urlparse(settings.SPID_SAML_CHECK_DEMO_METADATA_URL)
+def spid_demo_idp_active():
+    return settings.SPID_DEMO_IDP_ACTIVE
+
+
+@register.simple_tag()
+def spid_demo_url():
+    url = urlparse(settings.SPID_DEMO_METADATA_URL)
     return f'{url.scheme}://{url.netloc}{url.path.rpartition("/")[0]}'
+
+
+@register.simple_tag()
+def spid_validator_idp_active():
+    return settings.SPID_VALIDATOR_IDP_ACTIVE
+
+
+@register.simple_tag()
+def spid_validator_url():
+    url = urlparse(settings.SPID_VALIDATOR_METADATA_URL)
+    return f'{url.scheme}://{url.netloc}'
 
 
 @register.filter()


### PR DESCRIPTION
This PR updates settings of test IdPs, adding also a couple of configuration settings for SPID validator, useful when the onboarding procedure has to be done. Some settings ere renamed in order to match the current meaning of the configuration entry. When a test IdP is activated its name is added to the rendered *spid_button.html* template, so one doesn't need to provide an override to remove test IdPs from SPID button, but simply change the settings. 

Changes:
  - Add SPID_VALIDATOR_IDP_ACTIVE and SPID_VALIDATOR_METADATA_URL
  - SPID_SAML_CHECK_DEMO_REMOTE_METADATA_ACTIVE -> SPID_DEMO_IDP_ACTIVE
  - SPID_SAML_CHECK_DEMO_METADATA_URL -> SPID_DEMO_METADATA_URL
  - SPID_SAML_CHECK_REMOTE_METADATA_ACTIVE -> SPID_SAML_CHECK_IDP_ACTIVE
    (also checking the old name as fallback)
  - New template tags for checking if add test IdPs to SPID button

Note: it could be have a sense to add SPID validator and SPID Demo metadata to package or otherwise to update the _update_idps.py_ script to download also their metadata.