### PR TITLE
feat: CIE metadata endpoint and attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-SPID Django
+SPID/CIE Django
 -----------
 
 ![CI build](https://github.com/italia/spid-django/workflows/spid-django/badge.svg)
@@ -6,14 +6,14 @@ SPID Django
 ![License](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9-blue.svg)
 
 
-A SPID Service Provider based on [pysaml2](https://github.com/identitypython/pysaml2).
+A SPID/CIE Service Provider based on [pysaml2](https://github.com/identitypython/pysaml2).
 
 
 Introduction
 ------------
 
 This is a Django application that provides a SAML2 Service Provider
-for a Single Sign On with SPID, the Italian Digital Identity System.
+for a Single Sign On with SPID and CIE, the Italian Digital Identity System.
 
 This project comes with a demo on a Spid button template with both *spid-testenv2*
 and *spid-saml-check* IDP preconfigured. See running the Demo project paragaph for details.
@@ -24,6 +24,8 @@ within its CI pipeline, through [spid-sp-test](https://github.com/peppelinux/spi
 See github actions log for details.
 
 The technical documentation on SPID and SAML is available at [Docs Italia](https://docs.italia.it/italia/spid/spid-regole-tecniche)
+The technical documentation on CIE and SAML is available at [Docs Italia](https://docs.italia.it/italia/cie/cie-manuale-tecnico-docs)
+
 
 ![big picture](gallery/animated.gif)
 

--- a/example/spid_config/spid_settings.py
+++ b/example/spid_config/spid_settings.py
@@ -82,6 +82,39 @@ SPID_CONTACTS = [
 ]
 
 
+CIE_CONTACTS = [
+    {
+        'contact_type': 'administrative',
+        'IPACode': 'that-IPA-code',
+        'VATNumber': 'IT12345678901',
+        'FiscalCode': 'XYZABCAAMGGJ000W',
+        'NACE2Code': '12.34.56',
+        'Municipality': 'H501',
+        'Province': 'CS',
+        'Country': 'IT',
+        'Company': 'same-to-OrganizationName-if-PA',
+        'telephone_number': '+398475634785',
+        'email_address': 'tech-info@example.org',
+        'Public': '',
+    },
+    {
+        'contact_type': 'technical',
+        'telephone_number': '+39 84756344785',
+        'email_address': 'info@example.org',
+        'IPACode': 'that-IPA-code',
+        'VATNumber': 'IT12345678901',
+        'FiscalCode': 'XYZABCAAMGGJ000W',
+        'NACE2Code': '12.34.56',
+        'Municipality': 'H501',
+        'Province': 'CS',
+        'Country': 'IT',
+        'Company': 'same-to-OrganizationName-if-PA',
+        'telephone_number': '+398475634785',
+        'email_address': 'tech-info@example.org',
+    },
+]
+
+
 # Configuration for pysaml2 as managed by djangosaml2. For SPID SP service the most
 # part is built dynamically from provided SPID_* settings and from SPID_* defaults.
 SAML_CONFIG = {

--- a/src/djangosaml2_spid/tests.py
+++ b/src/djangosaml2_spid/tests.py
@@ -129,10 +129,6 @@ class TestSpidConfig(TestCase):
         saml_config = get_config()
         self.assertIsNone(saml_config.entityid)
 
-        request = self.factory.get("")
-        saml_config = get_config(request=request)
-        self.assertIsNone(saml_config.entityid)
-
         # SPConfig for a SPID request
         request = self.factory.get("/spid/metadata")
         saml_config = get_config(request=request)

--- a/src/djangosaml2_spid/urls.py
+++ b/src/djangosaml2_spid/urls.py
@@ -19,6 +19,9 @@ urlpatterns = [
         settings.SPID_METADATA_URL_PATH,
         views.MetadataSpidView.as_view(), name="spid_metadata"),
     path(
+        settings.CIE_METADATA_URL_PATH,
+        views.MetadataCieView.as_view(), name="cie_metadata"),
+    path(
         settings.SPID_ACS_URL_PATH,
         views.AssertionConsumerServiceView.as_view(),
         name="saml2_acs",


### PR DESCRIPTION
Here a way to handle a CIE SP integration in the existing SPID SP.

- feat: __/cie/metadata/__ endpoint  
- feat: SAML2 required attributes configured by matching on the metadata url path, if spid or cie  