### PR TITLE
Avoid 403 Erroro downloading IDP metadata

### DIFF
--- a/src/djangosaml2_spid/management/commands/update_idps.py
+++ b/src/djangosaml2_spid/management/commands/update_idps.py
@@ -64,7 +64,7 @@ class Command(BaseCommand):
                 indentation_level=1,
             )
 
-            #Add User-Agent heder to avoid 403 Forbidden error when downloading metada from poste.it
+            #Add User-Agent heder to avoid 403 Forbidden error when downloading metadata from poste.it
             with requests.get(idp_metadata_url, verify=True, headers={'User-Agent': ''}) as response:
                 identity_provider["metadata"] = response.text
 

--- a/src/djangosaml2_spid/management/commands/update_idps.py
+++ b/src/djangosaml2_spid/management/commands/update_idps.py
@@ -64,7 +64,7 @@ class Command(BaseCommand):
                 indentation_level=1,
             )
 
-            #Add User-Agent heder to avoid 403 Forbidden error when downloading metadata from poste.it
+            #Add User-Agent header to avoid 403 Forbidden error when downloading metadata from poste.it
             with requests.get(idp_metadata_url, verify=True, headers={'User-Agent': ''}) as response:
                 identity_provider["metadata"] = response.text
 

--- a/src/djangosaml2_spid/management/commands/update_idps.py
+++ b/src/djangosaml2_spid/management/commands/update_idps.py
@@ -64,7 +64,8 @@ class Command(BaseCommand):
                 indentation_level=1,
             )
 
-            with requests.get(idp_metadata_url, verify=True) as response:
+            #Add User-Agent heder to avoid 403 Forbidden error when downloading metada from poste.it
+            with requests.get(idp_metadata_url, verify=True, headers={'User-Agent': ''}) as response:
                 identity_provider["metadata"] = response.text
 
         self.print_success("All IdPs metadata downloaded successfully")


### PR DESCRIPTION
Add User-Agent header to avoid 403 Forbidden error when downloading metadata from poste.it